### PR TITLE
Enhance Status tab: node details, operator namespace & cluster info

### DIFF
--- a/lib/clusterStatusPoller.js
+++ b/lib/clusterStatusPoller.js
@@ -60,15 +60,22 @@ async function fetchClusterStatus(kubeconfigPath, installId) {
   const nodesResp = await coreApi.listNode();
   const nodes = (nodesResp.items || []).map(n => {
     const readyCond = (n.status.conditions || []).find(c => c.type === 'Ready');
-    const roles = Object.keys(n.metadata.labels || {})
+    const labels = n.metadata.labels || {};
+    const roles = Object.keys(labels)
       .filter(k => k.startsWith('node-role.kubernetes.io/'))
       .map(k => k.replace('node-role.kubernetes.io/', ''));
     return {
-      name:    n.metadata.name,
-      ready:   readyCond && readyCond.status === 'True',
-      roles:   roles.join(', ') || 'worker',
-      version: n.status.nodeInfo?.kubeletVersion || '',
-      age:     n.metadata.creationTimestamp,
+      name:         n.metadata.name,
+      ready:        readyCond && readyCond.status === 'True',
+      roles:        roles.join(', ') || 'worker',
+      version:      n.status.nodeInfo?.kubeletVersion || '',
+      age:          n.metadata.creationTimestamp,
+      instanceType: labels['node.kubernetes.io/instance-type']
+                      || labels['beta.kubernetes.io/instance-type']
+                      || '',
+      zone:         labels['topology.kubernetes.io/zone']
+                      || labels['failure-domain.beta.kubernetes.io/zone']
+                      || '',
     };
   });
 
@@ -85,6 +92,7 @@ async function fetchClusterStatus(kubeconfigPath, installId) {
       const progressing= (op.status?.conditions || []).find(c => c.type === 'Progressing');
       return {
         name:        op.metadata.name,
+        namespace:   '',
         available:   available?.status === 'True',
         degraded:    degraded?.status === 'True',
         progressing: progressing?.status === 'True',
@@ -106,6 +114,7 @@ async function fetchClusterStatus(kubeconfigPath, installId) {
       .filter(csv => csv.status?.reason !== 'Copied' && csv.status?.phase !== 'Replacing')
       .map(csv => ({
         name:        csv.metadata.name,
+        namespace:   csv.metadata.namespace || '',
         available:   csv.status?.phase === 'Succeeded',
         degraded:    csv.status?.phase === 'Failed',
         progressing: csv.status?.phase === 'Installing',
@@ -118,6 +127,28 @@ async function fetchClusterStatus(kubeconfigPath, installId) {
     operatorErrors.push(`OLM CSVs: ${err.message}`);
   }
 
+  // Fetch OCP version from ClusterVersion resource
+  let ocpVersion = '';
+  try {
+    const cv = await customApi.getClusterCustomObject({
+      group: 'config.openshift.io', version: 'v1', plural: 'clusterversions', name: 'version',
+    });
+    ocpVersion = cv.status?.desired?.version || cv.status?.history?.[0]?.version || '';
+  } catch (err) {
+    console.error('[clusterStatusPoller] Failed to fetch ClusterVersion:', err.message);
+  }
+
+  // Fetch infrastructure platform from Infrastructure resource
+  let infraProvider = '';
+  try {
+    const infra = await customApi.getClusterCustomObject({
+      group: 'config.openshift.io', version: 'v1', plural: 'infrastructures', name: 'cluster',
+    });
+    infraProvider = infra.status?.platform || infra.spec?.platformSpec?.type || '';
+  } catch (err) {
+    console.error('[clusterStatusPoller] Failed to fetch Infrastructure:', err.message);
+  }
+
   const install = stateStore.getInstall(installId);
   const consoleUrl = install
     ? `https://console-openshift-console.apps.${install.cluster_name}.${install.base_domain}`
@@ -126,7 +157,7 @@ async function fetchClusterStatus(kubeconfigPath, installId) {
     ? `https://api.${install.cluster_name}.${install.base_domain}:6443`
     : null;
 
-  return { nodes, operators, operatorErrors, apiUrl, consoleUrl };
+  return { nodes, operators, operatorErrors, apiUrl, consoleUrl, ocpVersion, infraProvider };
 }
 
 module.exports = { startPolling, stopPolling, fetchClusterStatus };

--- a/public/js/status.js
+++ b/public/js/status.js
@@ -41,7 +41,7 @@ async function loadStatus() {
     const status  = data.clusterStatus;
 
     if (!install || install.status !== 'complete') {
-      const nodesMsg = `<tr><td colspan="4" class="px-5 py-4 text-slate-500 text-center text-xs">Instalacja nie powiodła się — klaster niedostępny.</td></tr>`;
+      const nodesMsg = `<tr><td colspan="6" class="px-5 py-4 text-slate-500 text-center text-xs">Instalacja nie powiodła się — klaster niedostępny.</td></tr>`;
       const opsMsg   = `<tr><td colspan="5" class="px-5 py-4 text-slate-500 text-center text-xs">Instalacja nie powiodła się — klaster niedostępny.</td></tr>`;
       document.getElementById('nodesBody').innerHTML = nodesMsg;
       document.getElementById('operatorsBody').innerHTML = opsMsg;
@@ -52,7 +52,7 @@ async function loadStatus() {
     }
 
     if (!data.kubeconfigExists) {
-      const nodesMsg = `<tr><td colspan="4" class="px-5 py-4 text-slate-500 text-center text-xs">Kubeconfig niedostępny — sprawdź katalog instalacji.</td></tr>`;
+      const nodesMsg = `<tr><td colspan="6" class="px-5 py-4 text-slate-500 text-center text-xs">Kubeconfig niedostępny — sprawdź katalog instalacji.</td></tr>`;
       const opsMsg   = `<tr><td colspan="5" class="px-5 py-4 text-slate-500 text-center text-xs">Kubeconfig niedostępny — sprawdź katalog instalacji.</td></tr>`;
       document.getElementById('nodesBody').innerHTML = nodesMsg;
       document.getElementById('operatorsBody').innerHTML = opsMsg;
@@ -63,7 +63,7 @@ async function loadStatus() {
     }
 
     if (!status) {
-      const nodesMsg = `<tr><td colspan="4" class="px-5 py-4 text-slate-500 text-center text-xs">Brak danych — kliknij "Odśwież" aby załadować status klastra.</td></tr>`;
+      const nodesMsg = `<tr><td colspan="6" class="px-5 py-4 text-slate-500 text-center text-xs">Brak danych — kliknij "Odśwież" aby załadować status klastra.</td></tr>`;
       const opsMsg   = `<tr><td colspan="5" class="px-5 py-4 text-slate-500 text-center text-xs">Brak danych — kliknij "Odśwież" aby załadować status klastra.</td></tr>`;
       document.getElementById('nodesBody').innerHTML = nodesMsg;
       document.getElementById('operatorsBody').innerHTML = opsMsg;
@@ -72,6 +72,9 @@ async function loadStatus() {
       document.getElementById('operatorsReady').textContent = '';
       return;
     }
+
+    if (status.ocpVersion) document.getElementById('ocpVersion').textContent = status.ocpVersion;
+    if (status.infraProvider) document.getElementById('infraProvider').textContent = status.infraProvider;
 
     if (status.nodes) renderNodes(status.nodes);
     if (status.operators) renderOperators(status.operators, status.operatorErrors);
@@ -95,7 +98,7 @@ function renderNodes(nodes) {
   readyEl.className   = readyCount === nodes.length ? 'text-xs text-green-400' : 'text-xs text-yellow-400';
 
   if (!nodes.length) {
-    tbody.innerHTML = `<tr><td colspan="4" class="px-5 py-4 text-slate-600 text-center text-xs">Brak danych węzłów.</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="6" class="px-5 py-4 text-slate-600 text-center text-xs">Brak danych węzłów.</td></tr>`;
     return;
   }
 
@@ -111,6 +114,8 @@ function renderNodes(nodes) {
           ${n.ready ? 'Ready' : 'NotReady'}
         </span>
       </td>
+      <td class="px-5 py-3 font-mono text-xs text-slate-400">${n.instanceType || '-'}</td>
+      <td class="px-5 py-3 font-mono text-xs text-slate-400">${n.zone || '-'}</td>
       <td class="px-5 py-3 font-mono text-xs text-slate-500">${n.version || '-'}</td>
     </tr>
   `).join('');
@@ -128,7 +133,7 @@ function renderOperators(operators, operatorErrors) {
     const errMsg = operatorErrors && operatorErrors.length
       ? `Błąd pobierania operatorów: ${operatorErrors.join('; ')}`
       : 'Brak danych operatorów.';
-    tbody.innerHTML = `<tr><td colspan="5" class="px-5 py-4 text-slate-600 text-center text-xs">${errMsg}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="6" class="px-5 py-4 text-slate-600 text-center text-xs">${errMsg}</td></tr>`;
     return;
   }
 
@@ -137,15 +142,19 @@ function renderOperators(operators, operatorErrors) {
     const typeBadge = isOlm
       ? `<span class="px-1.5 py-0.5 rounded text-xs bg-blue-900/50 text-blue-400 font-mono">OLM</span>`
       : `<span class="px-1.5 py-0.5 rounded text-xs bg-slate-800 text-slate-400 font-mono">Platform</span>`;
+    const namespaceTd = op.namespace
+      ? `<td class="px-5 py-3 font-mono text-xs text-slate-400">${op.namespace}</td>`
+      : `<td class="px-5 py-3 text-xs text-slate-600 italic">cluster-scoped</td>`;
     return `
     <tr class="border-b border-slate-800/50 hover:bg-slate-800/30">
       <td class="px-5 py-3 font-mono text-xs text-slate-200">${op.name}</td>
+      ${namespaceTd}
       <td class="px-5 py-3">${typeBadge}</td>
       <td class="px-5 py-3 text-xs ${op.available ? 'text-green-400' : 'text-red-400'}">
         ${op.available ? '✓ Tak' : '✗ Nie'}
       </td>
-      <td class="px-5 py-3 text-xs ${op.degraded ? 'text-red-400' : 'text-slate-500'}">
-        ${op.degraded ? '✗ Tak' : '–'}
+      <td class="px-5 py-3 text-xs ${op.degraded ? 'text-red-400' : 'text-green-400'}">
+        ${op.degraded ? '✗ Tak' : '✓ Nie'}
       </td>
       <td class="px-5 py-3 font-mono text-xs text-slate-500">${op.version || '-'}</td>
     </tr>`;

--- a/views/status.ejs
+++ b/views/status.ejs
@@ -133,6 +133,8 @@
       <p class="text-slate-400 text-sm mt-0.5">
         Region: <span class="text-slate-200 font-mono"><%= install.gcp_region %></span>
         &nbsp;·&nbsp; Projekt: <span class="text-slate-200 font-mono"><%= install.gcp_project %></span>
+        &nbsp;·&nbsp; Wersja OCP: <span id="ocpVersion" class="text-slate-200 font-mono">...</span>
+        &nbsp;·&nbsp; Platforma: <span id="infraProvider" class="text-slate-200 font-mono">...</span>
       </p>
     </div>
     <div class="flex gap-2">
@@ -195,11 +197,13 @@
           <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Nazwa</th>
           <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Rola</th>
           <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Status</th>
+          <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Typ instancji</th>
+          <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Strefa</th>
           <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Wersja</th>
         </tr>
       </thead>
       <tbody id="nodesBody">
-        <tr><td colspan="4" class="px-5 py-4 text-slate-600 text-center text-xs">Ładowanie danych węzłów...</td></tr>
+        <tr><td colspan="6" class="px-5 py-4 text-slate-600 text-center text-xs">Ładowanie danych węzłów...</td></tr>
       </tbody>
     </table>
   </div>
@@ -214,6 +218,7 @@
       <thead>
         <tr class="border-b border-slate-800">
           <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Operator</th>
+          <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Namespace</th>
           <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Typ</th>
           <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Dostępny</th>
           <th class="text-left px-5 py-2.5 text-xs text-slate-500 uppercase tracking-wider font-medium">Degradowany</th>
@@ -221,7 +226,7 @@
         </tr>
       </thead>
       <tbody id="operatorsBody">
-        <tr><td colspan="5" class="px-5 py-4 text-slate-600 text-center text-xs">Ładowanie operatorów...</td></tr>
+        <tr><td colspan="6" class="px-5 py-4 text-slate-600 text-center text-xs">Ładowanie operatorów...</td></tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
## Summary
- **Węzły klastra**: added Instance Type and Zone columns (from standard k8s topology labels)
- **Operatory klastra**: added Namespace column (OLM operators show their namespace, platform operators show *cluster-scoped*); fixed Degradowany to show `✓ Nie` / `✗ Tak` instead of `–`
- **Klaster header**: added live OCP version and Infrastructure platform fetched from `ClusterVersion` and `Infrastructure` OpenShift custom resources

## Test plan
- [ ] Start server with `npm run dev`
- [ ] Open Status tab for a completed cluster install
- [ ] Click **Odśwież** — verify Wersja OCP and Platforma appear in cluster header
- [ ] Verify Węzły klastra shows Typ instancji and Strefa columns with real values
- [ ] Verify Operatory klastra Namespace column shows namespace for OLM operators and *cluster-scoped* for platform operators
- [ ] Verify Degradowany shows `✓ Nie` (green) for healthy operators

🤖 Generated with [Claude Code](https://claude.com/claude-code)