### PR TITLE
Add AI workload preparation wizard for installed clusters

### DIFF
--- a/lib/aiProcess.js
+++ b/lib/aiProcess.js
@@ -1,0 +1,455 @@
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const k8s  = require('@kubernetes/client-node');
+
+const stateStore = require('./stateStore');
+
+// installId -> true (running flag)
+const activeAiProcesses = new Map();
+
+const TOTAL_STEPS = 6;
+
+const OPERATORS = [
+  {
+    stepIndex:       1,
+    label:           'Node Feature Discovery (NFD) Operator',
+    namespace:       'openshift-nfd',
+    createNamespace: true,
+    operatorGroup: {
+      name:             'openshift-nfd',
+      targetNamespaces: ['openshift-nfd'],
+    },
+    subscription: {
+      name:    'nfd',
+      package: 'nfd',
+      channel: 'stable',
+      source:  'redhat-operators',
+    },
+    postInstall: async (customApi, emit) => {
+      emit('info', '[NFD] Tworzenie NodeFeatureDiscovery CR...');
+      await applyNamespacedCR(customApi, {
+        group:     'nfd.openshift.io',
+        version:   'v1',
+        plural:    'nodefeaturediscoveries',
+        namespace: 'openshift-nfd',
+        body: {
+          apiVersion: 'nfd.openshift.io/v1',
+          kind:       'NodeFeatureDiscovery',
+          metadata:   { name: 'nfd-instance', namespace: 'openshift-nfd' },
+          spec:       { operand: { servicePort: 12000 }, workerConfig: { configData: '' } },
+        },
+      });
+      emit('info', '[NFD] NodeFeatureDiscovery CR zastosowany.');
+    },
+  },
+  {
+    stepIndex:       2,
+    label:           'NVIDIA GPU Operator',
+    namespace:       'nvidia-gpu-operator',
+    createNamespace: true,
+    operatorGroup: {
+      name:             'nvidia-gpu-operator-group',
+      targetNamespaces: ['nvidia-gpu-operator'],
+    },
+    subscription: {
+      name:    'gpu-operator-certified',
+      package: 'gpu-operator-certified',
+      channel: 'v24.9',
+      source:  'certified-operators',
+    },
+    postInstall: async (customApi, emit) => {
+      emit('info', '[GPU] Tworzenie ClusterPolicy CR...');
+      await applyClusterCR(customApi, {
+        group:   'nvidia.com',
+        version: 'v1',
+        plural:  'clusterpolicies',
+        body: {
+          apiVersion: 'nvidia.com/v1',
+          kind:       'ClusterPolicy',
+          metadata:   { name: 'gpu-cluster-policy' },
+          spec: {
+            operator: {
+              defaultRuntime:       'crio',
+              use_ocp_driver_toolkit: true,
+              initContainer:        {},
+            },
+            sandboxWorkloads: {
+              enabled:         false,
+              defaultWorkload: 'container',
+            },
+            driver: {
+              enabled:              true,
+              useNvidiaDriverCRD:   false,
+              useOpenKernelModules: false,
+              upgradePolicy: {
+                autoUpgrade:        true,
+                maxParallelUpgrades: 1,
+                maxUnavailable:     '25%',
+                drain: {
+                  enable: false, force: false,
+                  deleteEmptyDir: false, timeoutSeconds: 300,
+                },
+                podDeletion: {
+                  force: false, deleteEmptyDir: false, timeoutSeconds: 300,
+                },
+                waitForCompletion: { timeoutSeconds: 0 },
+              },
+              repoConfig:        { configMapName: '' },
+              certConfig:        { name: '' },
+              licensingConfig:   { nlsEnabled: true, configMapName: '' },
+              virtualTopology:   { config: '' },
+              kernelModuleConfig: { name: '' },
+            },
+            dcgm:         { enabled: true },
+            dcgmExporter: {
+              enabled:        true,
+              config:         { name: '' },
+              serviceMonitor: { enabled: true },
+            },
+            // Required by the CRD — must be present
+            daemonsets: {
+              updateStrategy: 'RollingUpdate',
+              rollingUpdate:  { maxUnavailable: '1' },
+            },
+            devicePlugin: {
+              enabled: true,
+              config:  { name: '', default: '' },
+              mps:     { root: '/run/nvidia/mps' },
+            },
+            gfd:                { enabled: true },
+            migManager:         { enabled: true },
+            mig:                { strategy: 'single' },
+            nodeStatusExporter: { enabled: true },
+            toolkit:            { enabled: true },
+            validator: {
+              plugin: {
+                env: [{ name: 'WITH_WORKLOAD', value: 'false' }],
+              },
+            },
+            vgpuManager:         { enabled: false },
+            vgpuDeviceManager:   { enabled: true },
+            sandboxDevicePlugin: { enabled: true },
+            vfioManager:         { enabled: true },
+            gds:                 { enabled: false },
+            gdrcopy:             { enabled: false },
+          },
+        },
+      });
+      emit('info', '[GPU] ClusterPolicy CR zastosowany.');
+    },
+  },
+  {
+    stepIndex:       3,
+    label:           'OpenShift Service Mesh Operator',
+    namespace:       'openshift-operators',
+    createNamespace: false,
+    operatorGroup:   null, // already exists in openshift-operators
+    subscription: {
+      name:    'servicemeshoperator',
+      package: 'servicemeshoperator',
+      channel: 'stable',
+      source:  'redhat-operators',
+    },
+    postInstall: null,
+  },
+  {
+    stepIndex:       4,
+    label:           'Red Hat OpenShift Serverless Operator',
+    namespace:       'openshift-serverless',
+    createNamespace: true,
+    operatorGroup: {
+      name:             'serverless-operators',
+      targetNamespaces: [],  // AllNamespaces mode
+    },
+    subscription: {
+      name:    'serverless-operator',
+      package: 'serverless-operator',
+      channel: 'stable',
+      source:  'redhat-operators',
+    },
+    postInstall: null,
+  },
+  {
+    stepIndex:       5,
+    label:           'Red Hat Authorino Operator',
+    namespace:       'openshift-operators',
+    createNamespace: false,
+    operatorGroup:   null, // already exists in openshift-operators
+    subscription: {
+      name:    'authorino-operator',
+      package: 'authorino-operator',
+      channel: 'stable',
+      source:  'redhat-operators',
+    },
+    postInstall: null,
+  },
+  {
+    stepIndex:       6,
+    label:           'Red Hat OpenShift AI Operator',
+    namespace:       'redhat-ods-operator',
+    createNamespace: true,
+    operatorGroup: {
+      name:             'rhods-operator',
+      targetNamespaces: [],  // AllNamespaces mode — rhods-operator does not support OwnNamespace
+    },
+    subscription: {
+      name:    'rhods-operator',
+      package: 'rhods-operator',
+      channel: 'stable-3.x',
+      source:  'redhat-operators',
+    },
+    postInstall: async (customApi, emit) => {
+      emit('info', '[RHOAI] Tworzenie DataScienceCluster CR...');
+      await applyClusterCR(customApi, {
+        group:   'datasciencecluster.opendatahub.io',
+        version: 'v1',
+        plural:  'datascienceclusters',
+        body: {
+          apiVersion: 'datasciencecluster.opendatahub.io/v1',
+          kind:       'DataScienceCluster',
+          metadata:   { name: 'default-dsc' },
+          spec: {
+            components: {
+              dashboard:            { managementState: 'Managed' },
+              workbenches:          { managementState: 'Managed' },
+              datasciencepipelines: { managementState: 'Managed' },
+              modelmeshserving:     { managementState: 'Managed' },
+              kserve:               { managementState: 'Managed' },
+              ray:                  { managementState: 'Removed' },
+              kueue:                { managementState: 'Removed' },
+              trainingoperator:     { managementState: 'Removed' },
+              trustyai:             { managementState: 'Removed' },
+              modelregistry:        { managementState: 'Removed' },
+              codeflare:            { managementState: 'Removed' },
+            },
+          },
+        },
+      });
+      emit('info', '[RHOAI] DataScienceCluster CR zastosowany.');
+    },
+  },
+];
+
+// ── Helper: sleep ─────────────────────────────────────────────────────────────
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// ── Helper: extract HTTP status code from @kubernetes/client-node v1.x errors ─
+// v1.x throws ApiException with err.code (not err.response?.statusCode)
+
+function httpCode(err) {
+  return err?.code                                                        // ApiException v1.x
+    || err?.response?.statusCode                                          // older 0.x path
+    || err?.statusCode                                                    // some wrappers
+    || (typeof err?.message === 'string'
+        && Number(/HTTP-Code:\s*(\d+)/.exec(err.message)?.[1]))          // message fallback
+    || 0;
+}
+
+// ── Helper: apply (create, ignore AlreadyExists) ──────────────────────────────
+
+async function applyNamespace(coreApi, name) {
+  try {
+    await coreApi.createNamespace({ body: { apiVersion: 'v1', kind: 'Namespace', metadata: { name } } });
+  } catch (err) {
+    if (httpCode(err) !== 409) throw err;
+  }
+}
+
+async function applyNamespacedCR(customApi, { group, version, plural, namespace, body }) {
+  try {
+    await customApi.createNamespacedCustomObject({ group, version, namespace, plural, body });
+  } catch (err) {
+    if (httpCode(err) !== 409) throw err;
+  }
+}
+
+async function applyClusterCR(customApi, { group, version, plural, body }) {
+  try {
+    await customApi.createClusterCustomObject({ group, version, plural, body });
+  } catch (err) {
+    if (httpCode(err) !== 409) throw err;
+  }
+}
+
+// ── Helper: wait for CSV to reach Succeeded via subscription status ───────────
+
+async function waitForCsv(customApi, namespace, subscriptionName, emit, timeoutMs = 20 * 60 * 1000) {
+  const start = Date.now();
+  let lastPhase = '';
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const sub = await customApi.getNamespacedCustomObject({
+        group:     'operators.coreos.com',
+        version:   'v1alpha1',
+        namespace,
+        plural:    'subscriptions',
+        name:      subscriptionName,
+      });
+
+      const installedCSV = sub.status?.installedCSV;
+      const currentCSV   = sub.status?.currentCSV;
+      const state        = sub.status?.state;
+
+      if (installedCSV) {
+        try {
+          const csv = await customApi.getNamespacedCustomObject({
+            group:     'operators.coreos.com',
+            version:   'v1alpha1',
+            namespace,
+            plural:    'clusterserviceversions',
+            name:      installedCSV,
+          });
+          const phase = csv.status?.phase || 'Unknown';
+          if (phase !== lastPhase) {
+            emit('info', `  CSV ${installedCSV}: faza ${phase}`);
+            lastPhase = phase;
+          }
+          if (phase === 'Succeeded') return csv;
+          if (phase === 'Failed') throw new Error(`CSV ${installedCSV} zakończony błędem`);
+        } catch (csvErr) {
+          if (csvErr.message.includes('zakończony błędem')) throw csvErr;
+          // CSV not yet visible
+        }
+      } else if (currentCSV) {
+        if (state !== lastPhase) {
+          emit('debug', `  Subskrypcja: currentCSV=${currentCSV}, state=${state || 'pending'}`);
+          lastPhase = state || '';
+        }
+      } else {
+        emit('debug', `  Oczekiwanie na przetworzenie subskrypcji...`);
+      }
+    } catch (err) {
+      if (err.message.includes('zakończony błędem')) throw err;
+      emit('debug', `  Błąd odczytu subskrypcji: ${err.message}`);
+    }
+
+    await sleep(15 * 1000);
+  }
+
+  throw new Error(`Przekroczono czas oczekiwania na CSV dla ${subscriptionName} w ${namespace}`);
+}
+
+// ── Main: start AI operator installation ─────────────────────────────────────
+
+async function start(installId, installDir, io) {
+  if (activeAiProcesses.has(installId)) return;
+  activeAiProcesses.set(installId, true);
+
+  const room = `ai:${installId}`;
+
+  function emit(level, message, extra = {}) {
+    io.to(room).emit('ai:line', { level, message, ts: Date.now(), ...extra });
+  }
+
+  async function run() {
+    const kubeconfigPath = path.join(installDir, 'auth', 'kubeconfig');
+    if (!fs.existsSync(kubeconfigPath)) {
+      throw new Error(`Kubeconfig nie znaleziony: ${kubeconfigPath}`);
+    }
+
+    const kc = new k8s.KubeConfig();
+    kc.loadFromFile(kubeconfigPath);
+
+    const coreApi   = kc.makeApiClient(k8s.CoreV1Api);
+    const customApi = kc.makeApiClient(k8s.CustomObjectsApi);
+
+    emit('info', `Rozpoczynanie instalacji operatorów AI dla klastra...`);
+    emit('info', `Łączenie z klastrem przez kubeconfig: ${kubeconfigPath}`);
+
+    for (const op of OPERATORS) {
+      if (!activeAiProcesses.has(installId)) {
+        emit('warning', 'Instalacja anulowana.');
+        return;
+      }
+
+      emit('info', `\n── Krok ${op.stepIndex}/${TOTAL_STEPS}: ${op.label} ──`);
+      io.to(room).emit('ai:step_start', { stepIndex: op.stepIndex, label: op.label, totalSteps: TOTAL_STEPS });
+
+      // 1. Create namespace
+      if (op.createNamespace) {
+        emit('info', `[Krok ${op.stepIndex}] Tworzenie namespace: ${op.namespace}`);
+        await applyNamespace(coreApi, op.namespace);
+        emit('info', `[Krok ${op.stepIndex}] Namespace ${op.namespace} gotowy.`);
+      }
+
+      // 2. Create OperatorGroup
+      if (op.operatorGroup) {
+        emit('info', `[Krok ${op.stepIndex}] Tworzenie OperatorGroup: ${op.operatorGroup.name}`);
+        const ogBody = {
+          apiVersion: 'operators.coreos.com/v1',
+          kind:       'OperatorGroup',
+          metadata:   { name: op.operatorGroup.name, namespace: op.namespace },
+          spec:       {},
+        };
+        if (op.operatorGroup.targetNamespaces.length > 0) {
+          ogBody.spec.targetNamespaces = op.operatorGroup.targetNamespaces;
+        }
+        await applyNamespacedCR(customApi, {
+          group:     'operators.coreos.com',
+          version:   'v1',
+          plural:    'operatorgroups',
+          namespace: op.namespace,
+          body:      ogBody,
+        });
+        emit('info', `[Krok ${op.stepIndex}] OperatorGroup gotowy.`);
+      }
+
+      // 3. Create Subscription
+      emit('info', `[Krok ${op.stepIndex}] Tworzenie Subscription: ${op.subscription.name} (kanał: ${op.subscription.channel})`);
+      await applyNamespacedCR(customApi, {
+        group:     'operators.coreos.com',
+        version:   'v1alpha1',
+        plural:    'subscriptions',
+        namespace: op.namespace,
+        body: {
+          apiVersion: 'operators.coreos.com/v1alpha1',
+          kind:       'Subscription',
+          metadata:   { name: op.subscription.name, namespace: op.namespace },
+          spec: {
+            channel:             op.subscription.channel,
+            installPlanApproval: 'Automatic',
+            name:                op.subscription.package,
+            source:              op.subscription.source,
+            sourceNamespace:     'openshift-marketplace',
+          },
+        },
+      });
+      emit('info', `[Krok ${op.stepIndex}] Subscription utworzony. Oczekiwanie na instalację CSV...`);
+
+      // 4. Wait for CSV
+      await waitForCsv(customApi, op.namespace, op.subscription.name, emit);
+      emit('info', `[Krok ${op.stepIndex}] Operator ${op.label} zainstalowany pomyślnie.`);
+
+      // 5. Post-install CR
+      if (op.postInstall) {
+        await op.postInstall(customApi, emit);
+      }
+
+      io.to(room).emit('ai:step_done', { stepIndex: op.stepIndex, label: op.label, totalSteps: TOTAL_STEPS });
+    }
+
+    emit('info', '\n✓ Wszystkie operatory AI zainstalowane pomyślnie.');
+    stateStore.markAiEnabled(installId);
+    activeAiProcesses.delete(installId);
+    io.to(room).emit('ai:complete', { installId });
+  }
+
+  run().catch(err => {
+    console.error(`[aiProcess] Error for ${installId}:`, err.message);
+    io.to(room).emit('ai:line', { level: 'error', message: `✗ Błąd instalacji: ${err.message}`, ts: Date.now() });
+    activeAiProcesses.delete(installId);
+    io.to(room).emit('ai:failed', { installId, error: err.message });
+  });
+}
+
+function isRunning(installId) {
+  return activeAiProcesses.has(installId);
+}
+
+module.exports = { start, isRunning };

--- a/lib/stateStore.js
+++ b/lib/stateStore.js
@@ -69,6 +69,11 @@ function initialize() {
     db.exec('ALTER TABLE installs ADD COLUMN install_yaml TEXT DEFAULT NULL');
   } catch (_) { /* column already exists */ }
 
+  // Schema migration: track when AI operators were successfully installed on the cluster
+  try {
+    db.exec('ALTER TABLE installs ADD COLUMN ai_enabled_at INTEGER DEFAULT NULL');
+  } catch (_) { /* column already exists */ }
+
   // Backfill sa_project for existing records using .sa-key.json where available
   const needsBackfill = db.prepare(
     "SELECT install_id, install_dir, gcp_project FROM installs WHERE sa_project IS NULL AND install_dir IS NOT NULL"
@@ -165,6 +170,11 @@ function markDestroyed(installId) {
     .run(Date.now(), installId);
 }
 
+function markAiEnabled(installId) {
+  db.prepare(`UPDATE installs SET ai_enabled_at = ? WHERE install_id = ?`)
+    .run(Date.now(), installId);
+}
+
 function appendLog({ installId, lineNumber, level, message, raw, stage, ts }) {
   db.prepare(`
     INSERT INTO install_logs (install_id, line_number, level, message, raw, stage, ts)
@@ -211,6 +221,7 @@ module.exports = {
   getInstallsByProject,
   getLatestCompleteByProject,
   markDestroyed,
+  markAiEnabled,
   appendLog,
   getLogs,
   getLogCount,

--- a/public/js/ai.js
+++ b/public/js/ai.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const installId   = window.INSTALL_ID;
+let   lineCounter = 0;
+let   autoScroll  = true;
+
+const socket = io({ transports: ['websocket', 'polling'] });
+
+socket.on('connect', () => {
+  if (!installId) return;
+  socket.emit('ai:join', { installId });
+});
+
+socket.on('ai:line', (entry) => {
+  appendLogEntry(entry);
+});
+
+socket.on('ai:step_start', ({ stepIndex }) => {
+  markStepActive(stepIndex);
+});
+
+socket.on('ai:step_done', ({ stepIndex }) => {
+  markStepDone(stepIndex);
+});
+
+socket.on('ai:complete', () => {
+  applyStatus('complete');
+  appendSystemLine('✓ Wszystkie operatory AI zainstalowane. Klaster oznaczony jako AI-ready.');
+  document.getElementById('logCursor').classList.add('hidden');
+  showResult('complete');
+});
+
+socket.on('ai:failed', ({ error }) => {
+  applyStatus('failed');
+  appendSystemLine(`✗ Instalacja zakończona błędem: ${error || 'Nieznany błąd'}`, 'error');
+  document.getElementById('logCursor').classList.add('hidden');
+  showResult('failed', error);
+});
+
+socket.on('ai:status', ({ aiEnabledAt, isRunning }) => {
+  if (aiEnabledAt) {
+    applyStatus('complete');
+    document.getElementById('logCursor').classList.add('hidden');
+    showResult('complete');
+    // Mark all steps done
+    for (let i = 1; i <= 6; i++) markStepDone(i);
+  } else if (!isRunning) {
+    applyStatus('idle');
+  }
+});
+
+// ── Step indicator ────────────────────────────────────────────────────────────
+
+function markStepActive(stepIndex) {
+  const item = document.querySelector(`.step-item[data-step="${stepIndex}"]`);
+  if (!item) return;
+  const dot  = item.querySelector('.step-dot');
+  const icon = item.querySelector('.step-icon');
+  const text = item.querySelector('span:last-child');
+  dot.className  = 'step-dot w-5 h-5 rounded-full border border-blue-500 bg-blue-900/50 flex items-center justify-center flex-shrink-0';
+  icon.className = 'step-icon text-xs text-blue-400 animate-pulse';
+  icon.textContent = '●';
+  text.className = 'text-sm text-blue-300';
+}
+
+function markStepDone(stepIndex) {
+  const item = document.querySelector(`.step-item[data-step="${stepIndex}"]`);
+  if (!item) return;
+  const dot  = item.querySelector('.step-dot');
+  const icon = item.querySelector('.step-icon');
+  const text = item.querySelector('span:last-child');
+  dot.className  = 'step-dot w-5 h-5 rounded-full border border-green-600 bg-green-900/40 flex items-center justify-center flex-shrink-0';
+  icon.className = 'step-icon text-xs text-green-400';
+  icon.textContent = '✓';
+  text.className = 'text-sm text-green-300';
+}
+
+// ── Log rendering ─────────────────────────────────────────────────────────────
+const logLinesEl   = document.getElementById('logLines');
+const logContainer = document.getElementById('logContainer');
+const lineCountEl  = document.getElementById('lineCount');
+const autoScrollEl = document.getElementById('autoScrollToggle');
+
+autoScrollEl.addEventListener('change', () => {
+  autoScroll = autoScrollEl.checked;
+  if (autoScroll) scrollToBottom();
+});
+
+logContainer.addEventListener('scroll', () => {
+  const atBottom = logContainer.scrollHeight - logContainer.scrollTop <= logContainer.clientHeight + 50;
+  if (!atBottom && autoScrollEl.checked) {
+    autoScrollEl.checked = false;
+    autoScroll = false;
+  }
+});
+
+const LEVEL_COLORS = {
+  error:   'text-red-400',
+  warning: 'text-yellow-400',
+  warn:    'text-yellow-400',
+  debug:   'text-slate-500',
+  info:    'text-slate-200',
+};
+
+function appendLogEntry(entry) {
+  lineCounter++;
+  const el = buildLogLine({ ...entry, lineNumber: lineCounter });
+  logLinesEl.appendChild(el);
+  lineCountEl.textContent = `${lineCounter} linii`;
+  if (autoScroll) scrollToBottom();
+}
+
+function appendSystemLine(msg, level = 'info') {
+  lineCounter++;
+  logLinesEl.appendChild(buildLogLine({ lineNumber: lineCounter, level, message: msg, ts: Date.now() }));
+  if (autoScroll) scrollToBottom();
+}
+
+function buildLogLine(entry) {
+  const el    = document.createElement('div');
+  const time  = entry.ts ? new Date(entry.ts).toLocaleTimeString('pl-PL') : '';
+  const color = LEVEL_COLORS[entry.level] || 'text-slate-200';
+  el.innerHTML =
+    `<span class="select-none">` +
+    `<span class="text-slate-600 mr-1">${time}</span>` +
+    `<span class="text-slate-600 mr-2">[${(entry.level || 'info').toUpperCase().padEnd(5)}]</span>` +
+    `</span><span class="${color}">${escapeHtml(entry.message)}</span>`;
+  el.className = 'log-line leading-5';
+  return el;
+}
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function scrollToBottom() {
+  logContainer.scrollTop = logContainer.scrollHeight;
+}
+
+// ── Result banner ─────────────────────────────────────────────────────────────
+
+function showResult(status, error) {
+  const banner = document.getElementById('resultBanner');
+  const title  = document.getElementById('resultTitle');
+  const detail = document.getElementById('resultDetail');
+
+  if (status === 'complete') {
+    banner.className   = 'rounded-xl px-5 py-4 border bg-green-950/50 border-green-800';
+    title.className    = 'text-sm font-semibold text-green-300';
+    title.textContent  = '✓ Klaster przygotowany dla AI';
+    detail.className   = 'text-xs mt-1 text-green-400/70';
+    detail.textContent = 'Wszystkie wymagane operatory zostały zainstalowane. Klaster jest gotowy do obciążeń AI.';
+  } else {
+    banner.className   = 'rounded-xl px-5 py-4 border bg-red-950/50 border-red-800';
+    title.className    = 'text-sm font-semibold text-red-300';
+    title.textContent  = '✗ Błąd instalacji operatorów AI';
+    detail.className   = 'text-xs mt-1 text-red-400/70';
+    detail.textContent = error
+      ? `Szczegóły: ${error}. Sprawdź logi powyżej i spróbuj ponownie.`
+      : 'Sprawdź logi powyżej i spróbuj ponownie.';
+  }
+
+  banner.classList.remove('hidden');
+}
+
+// ── Status indicator ──────────────────────────────────────────────────────────
+
+function applyStatus(status) {
+  const indicator = document.getElementById('statusIndicator');
+  const text      = document.getElementById('statusText');
+
+  const MAP = {
+    complete: { dot: 'bg-green-400',                txt: 'text-green-300', label: 'Wszystkie operatory AI zainstalowane' },
+    failed:   { dot: 'bg-red-500',                  txt: 'text-red-400',   label: 'Błąd instalacji operatorów AI'        },
+    running:  { dot: 'bg-blue-400 animate-pulse',   txt: 'text-blue-300',  label: 'Instalacja operatorów AI w toku...'   },
+    idle:     { dot: 'bg-slate-500',                txt: 'text-slate-400', label: 'Oczekiwanie...'                       },
+  };
+
+  const s = MAP[status] || MAP.running;
+  indicator.className = `w-2.5 h-2.5 rounded-full ${s.dot}`;
+  text.className      = `text-sm font-medium ${s.txt}`;
+  text.textContent    = s.label;
+}

--- a/public/js/status.js
+++ b/public/js/status.js
@@ -259,6 +259,66 @@ function fallbackCopy(text, callback) {
   document.body.removeChild(ta);
 }
 
+// ── AI modal ──────────────────────────────────────────────────────────────────
+let aiTargetId = null;
+
+function openAiModal(id, name) {
+  aiTargetId = id;
+  document.getElementById('aiClusterName').textContent = name;
+  document.getElementById('aiError').classList.add('hidden');
+  document.getElementById('aiConfirmBtn').disabled = false;
+  document.getElementById('aiConfirmBtn').textContent = 'Uruchom instalację AI';
+  document.getElementById('aiModal').classList.remove('hidden');
+}
+
+function closeAiModal() {
+  document.getElementById('aiModal').classList.add('hidden');
+  aiTargetId = null;
+}
+
+async function confirmAiSetup() {
+  if (!aiTargetId) return;
+
+  const btn = document.getElementById('aiConfirmBtn');
+  const err = document.getElementById('aiError');
+  btn.disabled = true;
+  btn.textContent = 'Uruchamiam...';
+  err.classList.add('hidden');
+
+  try {
+    const resp = await fetch(`/ai/${aiTargetId}/start`, { method: 'POST' });
+    const data = await resp.json();
+
+    if (resp.status === 401) {
+      err.textContent = 'Sesja wygasła. Zaloguj się ponownie.';
+      err.classList.remove('hidden');
+      btn.disabled = false;
+      btn.textContent = 'Uruchom instalację AI';
+      return;
+    }
+
+    if (!resp.ok) {
+      err.textContent = data.error || 'Błąd uruchamiania instalacji AI.';
+      err.classList.remove('hidden');
+      btn.disabled = false;
+      btn.textContent = 'Uruchom instalację AI';
+      return;
+    }
+
+    window.location.href = `/ai/${aiTargetId}`;
+  } catch (e) {
+    err.textContent = `Błąd: ${e.message}`;
+    err.classList.remove('hidden');
+    btn.disabled = false;
+    btn.textContent = 'Uruchom instalację AI';
+  }
+}
+
+// Close AI modal on backdrop click
+document.getElementById('aiModal').addEventListener('click', (e) => {
+  if (e.target === document.getElementById('aiModal')) closeAiModal();
+});
+
 // ── Destroy modal ─────────────────────────────────────────────────────────────
 let destroyTargetId = null;
 

--- a/routes/ai.js
+++ b/routes/ai.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const express         = require('express');
+const router          = express.Router();
+const stateStore      = require('../lib/stateStore');
+const aiProcess       = require('../lib/aiProcess');
+const credentialStore = require('../lib/credentialStore');
+
+function requireAuth(req, res, next) {
+  if (!credentialStore.has(req.session.id)) {
+    if (req.method === 'GET') return res.redirect('/auth?warning=session_expired');
+    return res.status(401).json({ error: 'session_expired' });
+  }
+  next();
+}
+
+// Ownership check: same pattern as routes/destroy.js — compare GCP project IDs.
+// install.session_id reflects the session at install-time and changes on re-login,
+// so we use the project from the active credential instead.
+function canAccess(req, install) {
+  const projectId    = credentialStore.getProjectId(req.session.id);
+  const installOwner = install.sa_project || install.gcp_project;
+  return installOwner === projectId;
+}
+
+// GET /ai/:installId — progress page
+router.get('/:installId', requireAuth, (req, res) => {
+  const { installId } = req.params;
+  const install = stateStore.getInstall(installId);
+
+  if (!install)               return res.redirect('/status');
+  if (!canAccess(req, install)) return res.redirect('/status');
+
+  res.render('ai', { installId, install });
+});
+
+// POST /ai/:installId/start — begin AI operator installation
+router.post('/:installId/start', requireAuth, (req, res) => {
+  const { installId } = req.params;
+  const install = stateStore.getInstall(installId);
+
+  if (!install)
+    return res.status(404).json({ error: 'Nie znaleziono instalacji.' });
+  if (!canAccess(req, install))
+    return res.status(403).json({ error: 'Brak dostępu do tego klastra.' });
+  if (install.status !== 'complete')
+    return res.status(400).json({ error: 'Klaster musi być w stanie complete.' });
+  if (install.ai_enabled_at)
+    return res.status(400).json({ error: 'Klaster jest już przygotowany dla AI.' });
+  if (aiProcess.isRunning(installId))
+    return res.status(400).json({ error: 'Instalacja AI jest już w toku.' });
+  if (!install.install_dir)
+    return res.status(400).json({ error: 'Brak katalogu instalacji (install_dir).' });
+
+  const io = req.app.get('io');
+  aiProcess.start(installId, install.install_dir, io);
+
+  res.json({ ok: true });
+});
+
+// GET /ai/:installId/status — current AI status (for polling)
+router.get('/:installId/status', requireAuth, (req, res) => {
+  const { installId } = req.params;
+  const install = stateStore.getInstall(installId);
+
+  if (!install)
+    return res.status(404).json({ error: 'Nie znaleziono instalacji.' });
+  if (!canAccess(req, install))
+    return res.status(403).json({ error: 'Brak dostępu do tego klastra.' });
+
+  res.json({
+    aiEnabledAt: install.ai_enabled_at || null,
+    isRunning:   aiProcess.isRunning(installId),
+  });
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -132,6 +132,7 @@ async function main() {
   app.use('/install',              require('./routes/install'));
   app.use('/status',               require('./routes/status'));
   app.use('/destroy',              require('./routes/destroy'));
+  app.use('/ai',                   require('./routes/ai'));
   app.use('/download',             require('./routes/download'));
 
   // ── 8. Socket.io ──────────────────────────────────────────────────────────────

--- a/sockets/installSocket.js
+++ b/sockets/installSocket.js
@@ -2,9 +2,27 @@
 
 const stateStore     = require('../lib/stateStore');
 const destroyProcess = require('../lib/destroyProcess');
+const aiProcess      = require('../lib/aiProcess');
 
 function attachSocketHandlers(io) {
   io.on('connection', (socket) => {
+
+    // Client joins AI room
+    socket.on('ai:join', ({ installId }) => {
+      if (!installId) return;
+      socket.join(`ai:${installId}`);
+
+      const install = stateStore.getInstall(installId);
+      if (!install) return;
+
+      if (install.ai_enabled_at) {
+        // Already complete — notify immediately
+        socket.emit('ai:status', { aiEnabledAt: install.ai_enabled_at, isRunning: false });
+        socket.emit('ai:complete', { installId });
+      } else {
+        socket.emit('ai:status', { aiEnabledAt: null, isRunning: aiProcess.isRunning(installId) });
+      }
+    });
 
     // Client joins destroy room
     socket.on('destroy:join', ({ installId }) => {

--- a/views/ai.ejs
+++ b/views/ai.ejs
@@ -1,0 +1,116 @@
+<%- include('_head', { title: 'Przygotowanie AI', currentPath: '/status' }) %>
+
+<div class="space-y-4">
+
+  <div>
+    <h1 class="text-2xl font-bold text-white">Przygotowanie klastra dla AI</h1>
+    <% if (install) { %>
+      <p class="text-slate-400 text-sm mt-0.5">
+        Klaster: <span class="text-slate-200 font-mono"><%= install.cluster_name %>.<%= install.base_domain %></span>
+        &nbsp;·&nbsp; Projekt: <span class="text-slate-200 font-mono"><%= install.gcp_project %></span>
+      </p>
+    <% } %>
+  </div>
+
+  <!-- Status indicator -->
+  <div class="bg-slate-900 border border-slate-700 rounded-xl p-5">
+    <div class="flex items-center gap-2">
+      <div id="statusIndicator" class="w-2.5 h-2.5 rounded-full bg-blue-400 animate-pulse"></div>
+      <span id="statusText" class="text-sm font-medium text-blue-300">Instalacja operatorów AI w toku...</span>
+    </div>
+  </div>
+
+  <!-- Step progress -->
+  <div class="bg-slate-900 border border-slate-700 rounded-xl p-5">
+    <h2 class="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-4">Postęp instalacji</h2>
+    <div class="space-y-2" id="stepsList">
+      <div class="step-item flex items-center gap-3" data-step="1">
+        <div class="step-dot w-5 h-5 rounded-full border border-slate-600 bg-slate-800 flex items-center justify-center flex-shrink-0">
+          <span class="step-icon text-xs text-slate-500">1</span>
+        </div>
+        <span class="text-sm text-slate-400">Node Feature Discovery (NFD) Operator</span>
+      </div>
+      <div class="step-item flex items-center gap-3" data-step="2">
+        <div class="step-dot w-5 h-5 rounded-full border border-slate-600 bg-slate-800 flex items-center justify-center flex-shrink-0">
+          <span class="step-icon text-xs text-slate-500">2</span>
+        </div>
+        <span class="text-sm text-slate-400">NVIDIA GPU Operator</span>
+      </div>
+      <div class="step-item flex items-center gap-3" data-step="3">
+        <div class="step-dot w-5 h-5 rounded-full border border-slate-600 bg-slate-800 flex items-center justify-center flex-shrink-0">
+          <span class="step-icon text-xs text-slate-500">3</span>
+        </div>
+        <span class="text-sm text-slate-400">OpenShift Service Mesh Operator</span>
+      </div>
+      <div class="step-item flex items-center gap-3" data-step="4">
+        <div class="step-dot w-5 h-5 rounded-full border border-slate-600 bg-slate-800 flex items-center justify-center flex-shrink-0">
+          <span class="step-icon text-xs text-slate-500">4</span>
+        </div>
+        <span class="text-sm text-slate-400">Red Hat OpenShift Serverless Operator</span>
+      </div>
+      <div class="step-item flex items-center gap-3" data-step="5">
+        <div class="step-dot w-5 h-5 rounded-full border border-slate-600 bg-slate-800 flex items-center justify-center flex-shrink-0">
+          <span class="step-icon text-xs text-slate-500">5</span>
+        </div>
+        <span class="text-sm text-slate-400">Red Hat Authorino Operator</span>
+      </div>
+      <div class="step-item flex items-center gap-3" data-step="6">
+        <div class="step-dot w-5 h-5 rounded-full border border-slate-600 bg-slate-800 flex items-center justify-center flex-shrink-0">
+          <span class="step-icon text-xs text-slate-500">6</span>
+        </div>
+        <span class="text-sm text-slate-400">Red Hat OpenShift AI Operator</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Result banner (shown after complete or failed) -->
+  <div id="resultBanner" class="hidden rounded-xl px-5 py-4 border">
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <p id="resultTitle" class="text-sm font-semibold"></p>
+        <p id="resultDetail" class="text-xs mt-1 opacity-75"></p>
+      </div>
+      <a href="/status"
+         class="px-4 py-2 text-sm font-medium bg-slate-800 hover:bg-slate-700 border border-slate-600 hover:border-slate-500 text-slate-200 rounded-lg transition-colors whitespace-nowrap flex-shrink-0">
+        Przejdź do Status →
+      </a>
+    </div>
+  </div>
+
+  <!-- Terminal log viewer -->
+  <div class="bg-slate-950 border border-slate-700 rounded-xl overflow-hidden">
+    <div class="flex items-center gap-3 px-4 py-2.5 bg-slate-900 border-b border-slate-700">
+      <div class="flex gap-1.5">
+        <div class="w-3 h-3 rounded-full bg-red-500/60"></div>
+        <div class="w-3 h-3 rounded-full bg-yellow-500/60"></div>
+        <div class="w-3 h-3 rounded-full bg-green-500/60"></div>
+      </div>
+      <span class="text-xs text-slate-500 font-mono">AI Operator Installation</span>
+      <label class="ml-auto flex items-center gap-1.5 text-xs text-slate-500 cursor-pointer">
+        <input type="checkbox" id="autoScrollToggle" checked class="accent-rh-red w-3 h-3">
+        Auto-scroll
+      </label>
+      <span id="lineCount" class="text-xs text-slate-600 font-mono">0 linii</span>
+    </div>
+
+    <div id="logContainer" class="h-[28rem] overflow-y-auto p-4 font-mono text-xs leading-5">
+      <div id="logLines"></div>
+      <div id="logCursor" class="inline-block w-2 h-3.5 bg-slate-500 animate-pulse ml-0.5"></div>
+    </div>
+  </div>
+
+  <div class="bg-blue-950/50 border border-blue-900 rounded-xl px-5 py-3 text-sm text-blue-300">
+    <span class="font-medium">Instalacja może trwać 30–60 minut.</span>
+    Każdy operator wymaga czasu na pobranie i uruchomienie składników.
+  </div>
+
+</div>
+
+<%- include('_foot') %>
+<script src="/socket.io/socket.io.js"></script>
+<script>
+  window.INSTALL_ID = '<%= installId %>';
+</script>
+<script src="/js/ai.js"></script>
+</body>
+</html>

--- a/views/status.ejs
+++ b/views/status.ejs
@@ -63,11 +63,29 @@
                 <% } %>
               </td>
               <td class="px-5 py-3 text-right">
-                <button
-                  onclick="openDestroyModal('<%= cl.install_id %>', '<%= cl.cluster_name %>.<%= cl.base_domain %>')"
-                  class="px-2.5 py-1 text-xs border border-red-900 hover:border-rh-red text-red-500 hover:text-red-400 rounded transition-colors">
-                  Usuń klaster
-                </button>
+                <div class="flex items-center justify-end gap-2">
+                  <% if (cl.status === 'complete') { %>
+                    <% if (cl.ai_enabled_at) { %>
+                      <span class="flex items-center gap-1 px-2.5 py-1 text-xs border border-purple-800 text-purple-400 rounded bg-purple-950/30" title="Operatory AI zainstalowane">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3H5a2 2 0 00-2 2v4m6-6h10a2 2 0 012 2v4M9 3v18m0 0h10a2 2 0 002-2V9M9 21H5a2 2 0 01-2-2V9m0 0h18"/>
+                        </svg>
+                        AI Ready
+                      </span>
+                    <% } else { %>
+                      <button
+                        onclick="openAiModal('<%= cl.install_id %>', '<%= cl.cluster_name %>.<%= cl.base_domain %>')"
+                        class="px-2.5 py-1 text-xs border border-purple-800 hover:border-purple-600 text-purple-400 hover:text-purple-300 rounded transition-colors">
+                        Przygotuj dla AI
+                      </button>
+                    <% } %>
+                  <% } %>
+                  <button
+                    onclick="openDestroyModal('<%= cl.install_id %>', '<%= cl.cluster_name %>.<%= cl.base_domain %>')"
+                    class="px-2.5 py-1 text-xs border border-red-900 hover:border-rh-red text-red-500 hover:text-red-400 rounded transition-colors">
+                    Usuń klaster
+                  </button>
+                </div>
               </td>
             </tr>
           <% }); %>
@@ -237,6 +255,49 @@
   </p>
 
   <% } %>
+
+  <!-- AI preparation confirmation modal -->
+  <div id="aiModal" class="hidden fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+    <div class="bg-slate-900 border border-purple-800 rounded-xl p-6 max-w-lg w-full mx-4">
+      <h3 class="text-lg font-bold text-white mb-2">Przygotowanie klastra dla AI</h3>
+      <p class="text-slate-400 text-sm mb-1">Klaster: <span id="aiClusterName" class="text-slate-200 font-mono text-xs"></span></p>
+      <p class="text-slate-400 text-sm mb-3">Zostaną zainstalowane następujące operatory:</p>
+      <ul class="mb-4 space-y-1.5">
+        <li class="flex items-center gap-2 text-xs text-slate-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-purple-400 flex-shrink-0"></span>Node Feature Discovery (NFD) Operator
+        </li>
+        <li class="flex items-center gap-2 text-xs text-slate-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-purple-400 flex-shrink-0"></span>NVIDIA GPU Operator
+        </li>
+        <li class="flex items-center gap-2 text-xs text-slate-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-purple-400 flex-shrink-0"></span>OpenShift Service Mesh Operator
+        </li>
+        <li class="flex items-center gap-2 text-xs text-slate-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-purple-400 flex-shrink-0"></span>Red Hat OpenShift Serverless Operator
+        </li>
+        <li class="flex items-center gap-2 text-xs text-slate-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-purple-400 flex-shrink-0"></span>Red Hat Authorino Operator
+        </li>
+        <li class="flex items-center gap-2 text-xs text-slate-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-purple-400 flex-shrink-0"></span>Red Hat OpenShift AI Operator
+        </li>
+      </ul>
+      <p class="text-yellow-400/80 text-xs mb-4">
+        ⚠ Instalacja może trwać <strong>30–60 minut</strong>. Klaster pozostanie dostępny.
+      </p>
+      <div id="aiError" class="hidden mb-3 p-3 bg-red-950/50 border border-red-800 rounded-lg text-xs text-red-300"></div>
+      <div class="flex gap-3">
+        <button onclick="closeAiModal()"
+                class="flex-1 py-2 border border-slate-600 text-slate-300 rounded-lg text-sm hover:border-slate-400 transition-colors">
+          Anuluj
+        </button>
+        <button id="aiConfirmBtn" onclick="confirmAiSetup()"
+                class="flex-1 py-2 bg-purple-700 hover:bg-purple-600 text-white rounded-lg text-sm transition-colors">
+          Uruchom instalację AI
+        </button>
+      </div>
+    </div>
+  </div>
 
   <!-- Destroy confirmation modal -->
   <div id="destroyModal" class="hidden fixed inset-0 bg-black/70 flex items-center justify-center z-50">


### PR DESCRIPTION
## Summary

- Implements [issue #5](https://github.com/mmartofel/ocp-ui-install-gcp/issues/5): adds a **Przygotuj dla AI** button on the Status page for each active cluster
- Clicking the button opens a confirmation modal listing all 6 required AI operators, then navigates to a live progress page that streams installation logs via Socket.io
- Once all operators are installed the cluster is marked **AI Ready** (badge replaces the button) and the state is persisted in the database (`ai_enabled_at`)

Operators installed in dependency order:
1. Node Feature Discovery (NFD) — `openshift-nfd`, channel `stable`
2. NVIDIA GPU Operator — `nvidia-gpu-operator`, channel `v24.9`
3. OpenShift Service Mesh — `openshift-operators`, channel `stable`
4. OpenShift Serverless — `openshift-serverless`, channel `stable`
5. Authorino — `openshift-operators`, channel `stable`
6. Red Hat OpenShift AI (RHOAI) — `redhat-ods-operator`, channel `stable-3.x`

## Implementation notes

- `lib/aiProcess.js` uses `@kubernetes/client-node` (already a project dependency) — no new binaries required
- Ownership check in `routes/ai.js` uses the same GCP project-based pattern as `routes/destroy.js`
- All resource creation is idempotent: 409 AlreadyExists errors are silently ignored, so retries are safe
- Error handling accounts for `@kubernetes/client-node` v1.x `ApiException.code` (not `response.statusCode`)

## Test plan

- [ ] Navigate to `/status` with a complete cluster — verify **Przygotuj dla AI** button appears
- [ ] Click button — verify confirmation modal lists all 6 operators with 30–60 min warning
- [ ] Confirm — verify navigation to `/ai/:installId` progress page with live terminal log
- [ ] Verify step indicator advances as each operator completes
- [ ] After completion — verify **AI Ready** badge replaces the button on the Status page
- [ ] Reload `/ai/:installId` after completion — verify `ai:complete` is replayed immediately via socket
- [ ] Retry after partial failure — verify already-installed resources are skipped cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)