### PR TITLE
Fix GPU MachineSet: restartPolicy Always, remove preemptible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ data/installer/
 data/db/
 tmp/
 *.log
+*.gz
 pull-secret.yaml
 pull-secret.json
 pull-secret.txt

--- a/lib/machinesetProcess.js
+++ b/lib/machinesetProcess.js
@@ -141,8 +141,7 @@ async function start(installId, installDir, params, io) {
     ps.machineType       = params.machineType;
     ps.zone              = params.zone;
     ps.onHostMaintenance = 'Terminate';
-    ps.restartPolicy     = 'Never';
-    ps.preemptible       = true;
+    ps.restartPolicy     = 'Always';
 
     // Add GPU=YES label to node template
     if (!newMs.spec.template.spec.metadata) {


### PR DESCRIPTION
## Summary

- Fix `restartPolicy` from `'Never'` to `'Always'` in GPU MachineSet providerSpec (`lib/machinesetProcess.js`)
- Remove `preemptible: true` — not present in working reference MachineSet; would silently create spot VMs instead of standard GPU instances

GCP requires `onHostMaintenance: Terminate` + `restartPolicy: Always` for GPU VM types (live migration unsupported). The `preemptible` flag was incorrect and caused GPU nodes to be provisioned as preemptible/spot instances.

## Test plan

- [ ] Create a GPU MachineSet via the UI wizard
- [ ] Verify: `oc get machineset <name> -n openshift-machine-api -o yaml | grep -E 'onHostMaintenance|restartPolicy|preemptible'`
- [ ] Expected: `onHostMaintenance: Terminate`, `restartPolicy: Always`, no `preemptible` field
- [ ] Confirm GPU node reaches `Ready` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)